### PR TITLE
Fix fall through compiler error

### DIFF
--- a/src/PicoMQTT/outgoing_packet.cpp
+++ b/src/PicoMQTT/outgoing_packet.cpp
@@ -214,6 +214,7 @@ bool OutgoingPacket::send() {
         case State::ok:
             // print.flush();
             state = State::sent;
+            __attribute__ ((fallthrough));
         case State::sent:
             return true;
         default:


### PR DESCRIPTION
Setting build_flag -Werror detects a missing break statement in a switch case as an error. Tell the compiler that this is indential. This fixes #20.